### PR TITLE
Enable sign-in for user using basic auth

### DIFF
--- a/dev-org/dev-org/JSAPI.h
+++ b/dev-org/dev-org/JSAPI.h
@@ -17,9 +17,12 @@ typedef void(^DevCompletion)(NSArray<Developer *> *allDevs);
 typedef void(^NPOCompletion)(NSArray<Organization *> *allOrganizations);
 typedef void(^ProjectCompletion)(NSArray<Project *> *projects);
 typedef void(^ReviewCompletion)(Review *review);
+typedef void(^SignInCompletion)(NSString *token);
 
 @interface JSAPI : NSObject
 
+
++(void)signInWithUsername:(NSString*)username password:(NSString*)password andCompletion:(SignInCompletion)completion;
 
 +(void)fetchAllDevelopers:(DevCompletion)completion;
 

--- a/dev-org/dev-org/MainViewController.m
+++ b/dev-org/dev-org/MainViewController.m
@@ -10,6 +10,7 @@
 #import "Developer.h"
 #import "Organization.h"
 #import "JSAPIPOSTRequest.h"
+#import "JSAPI.h"
 
 @interface MainViewController ()
 
@@ -80,7 +81,17 @@
 }
 
 - (IBAction)loginPressed:(UIButton *)sender {
+    self.user = [[User alloc] init];
+    __weak typeof(self) bruce = self;
     
+    [JSAPI signInWithUsername:(NSString*)self.loginUsername.text password:(NSString*)self.loginPassword.text andCompletion:^(NSString *identifier) {
+        __strong typeof(bruce) hulk = bruce;
+        
+        // Remove quotation marks from string before assigning to user
+        hulk.user.userToken = [identifier componentsSeparatedByString:@"\""][1];
+        NSLog(@"testing login");
+        [hulk saveUser];
+    }];
 }
 
 


### PR DESCRIPTION
This only retrieves a token and stores it on a basic User object. It's
 currently directing the user to the view for NPOs, but the token can
 now be used for any post/put requests that aren't limited by user type.